### PR TITLE
Remove unused variable in begin()

### DIFF
--- a/DFRobot_SHT3x.cpp
+++ b/DFRobot_SHT3x.cpp
@@ -26,7 +26,6 @@ DFRobot_SHT3x::DFRobot_SHT3x(TwoWire *pWire, uint8_t address,uint8_t RST)
 int DFRobot_SHT3x::begin() 
 {
   _pWire->begin();
-  uint8_t data[2];
   if(readSerialNumber() == 0){
     DBG("bus data access error");
     return ERR_DATA_BUS;


### PR DESCRIPTION
`uint8_t data[2]` variable is never used. This commit removes it. This resolves a compiler warning on my side which detects unused variables.