### PR TITLE
Fix conversion to Farenheit

### DIFF
--- a/DFRobot_SHT3x.cpp
+++ b/DFRobot_SHT3x.cpp
@@ -153,7 +153,7 @@ DFRobot_SHT3x::sRHAndTemp_t DFRobot_SHT3x::readTemperatureAndHumidity(eRepeatabi
     return tempRH;
   }
   tempRH.TemperatureC = convertTemperature(rawTemperature);
-  tempRH.TemperatureF = (9/5)*tempRH.TemperatureC+32;
+  tempRH.TemperatureF = (9.0/5.0)*tempRH.TemperatureC+32;
   tempRH.Humidity = convertHumidity(rawHumidity);
   return tempRH;
 }
@@ -279,7 +279,7 @@ DFRobot_SHT3x::sRHAndTemp_t DFRobot_SHT3x::readTemperatureAndHumidity()
   }
   tempRH.TemperatureC = convertTemperature(rawTemperature);
   tempRH.Humidity = convertHumidity(rawHumidity);
-  tempRH.TemperatureF = (9/5)*tempRH.TemperatureC+32;
+  tempRH.TemperatureF = (9.0/5.0)*tempRH.TemperatureC+32;
   return tempRH;
 }
 


### PR DESCRIPTION
@LZY1586 - will need to update the screenshots on the DFRobot Wiki too:
https://wiki.dfrobot.com/Gravity:%20SHT31-F%20Digital%20Temperature%20and%20Humidity%20Sensor%20SKU:%20SEN0334

9/5 = 1 in integer math.

Change to 9.0/5.0 to get the correct result (1.8)

See Core Electronics forums for full explanation:
https://forum.core-electronics.com.au/t/sensor-sen-0334/10139/4